### PR TITLE
Fix associated connections

### DIFF
--- a/phuepanelmenu.js
+++ b/phuepanelmenu.js
@@ -675,15 +675,15 @@ var PhuePanelMenu = GObject.registerClass({
 
         let id = [];
 
-        if (this._client === undefined) {
+        if (this._networkClient === undefined) {
             return id;
         }
 
-        if (! this._client.networking_enabled) {
+        if (! this._networkClient.networking_enabled) {
             return id;
         }
 
-        let activeConnections = this._client.get_active_connections();
+        let activeConnections = this._networkClient.get_active_connections();
 
         for (let connection of activeConnections) {
             if (! Utils.allowedConnectionTypes.includes(connection.get_connection_type())) {


### PR DESCRIPTION
`_client` was renamed to `_networkClient` in commit a23cefa84e1be3211d7ddb7661c867cc333efec6, but not everywhere.

It fixes #55.